### PR TITLE
Improve PDF extraction reliability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.28.0
 beautifulsoup4>=4.12.0
 datasets>=2.0.0
 huggingface-hub>=0.13.0
+pdfminer.six>=20221105


### PR DESCRIPTION
## Summary
- ensure HTTP response really contains a PDF
- add a fallback using `pdfminer.six` when `pdftotext` yields no text
- add `pdfminer.six` to dependencies

## Testing
- `python -m py_compile nationale_assemblee_scraper_to_hf.py`
- `python -m py_compile sru_scraper.py sris_scraper.py upload_to_drive.py`

------
https://chatgpt.com/codex/tasks/task_b_686d479f755c832fbb35a4f3face7fd6