### PR TITLE
Update scraper to fetch from SRIS

### DIFF
--- a/nationale_assemblee_scraper_to_hf.py
+++ b/nationale_assemblee_scraper_to_hf.py
@@ -10,7 +10,17 @@ from datasets import Dataset
 from huggingface_hub import HfApi
 
 # Configuration
-BASE_URL = "https://www.dna.sr/wetgeving/surinaamse-wetten/"
+# Target URLs from SRIS
+URLS = [
+    "https://www.sris.sr/administratief-recht/",
+    "https://www.sris.sr/burgerlijk-recht/",
+    "https://www.sris.sr/burgerlijk-procesrecht/",
+    "https://www.sris.sr/staatsrecht/",
+    "https://www.sris.sr/strafrecht/",
+    "https://www.sris.sr/strafprocesrecht/",
+    "https://www.sris.sr/wettenarchief/",
+]
+BASE_DOMAIN = urlparse(URLS[0]).netloc
 OUTPUT_DIR = "downloaded_pdfs"
 HF_REPO_ID = "vGassen/Surinam-Dutch-Legislation"
 SOURCE_NAME = "Nationale Assemblee Suriname"
@@ -28,7 +38,7 @@ def is_valid_pdf_link(href: str) -> bool:
 
 def is_internal_link(href: str) -> bool:
     parsed = urlparse(href)
-    return not parsed.netloc or parsed.netloc == urlparse(BASE_URL).netloc
+    return not parsed.netloc or parsed.netloc == BASE_DOMAIN
 
 
 def convert_pdf_to_text(pdf_bytes: bytes) -> str:
@@ -117,7 +127,7 @@ def scrape(url: str) -> None:
         full = urljoin(url, href)
         if is_valid_pdf_link(full):
             download_and_extract(full)
-        elif is_internal_link(href) and BASE_URL in full:
+        elif is_internal_link(full):
             scrape(full)
 
 
@@ -139,5 +149,6 @@ def push_to_hf(docs_list: list, repo_id: str) -> None:
 
 
 if __name__ == '__main__':
-    scrape(BASE_URL)
+    for start_url in URLS:
+        scrape(start_url)
     push_to_hf(docs, HF_REPO_ID)

--- a/readme.me
+++ b/readme.me
@@ -4,7 +4,7 @@ This repository provides small Python scripts to download Surinamese legislation
 
 ## Overview
 
-- `nationale_assemblee_scraper_to_hf.py` crawls the Surinamese National Assembly website, collects PDF files, converts them to plain text with `pdftotext` and uploads the resulting dataset to Hugging Face.
+- `nationale_assemblee_scraper_to_hf.py` downloads legislation PDFs from the Suriname Rechtsinstituut (SRIS), converts them to plain text with `pdftotext` and uploads the resulting dataset to Hugging Face.
 - `sru_scraper.py` recursively downloads PDFs from the same site without uploading.
 - `sris_scraper.py` downloads legislation PDFs from the Suriname Rechtsinstituut for several legal categories.
 - `upload_to_drive.py` uploads a zipped folder of PDFs to Google Drive using PyDrive.


### PR DESCRIPTION
## Summary
- switch `nationale_assemblee_scraper_to_hf.py` to scrape SRIS URLs
- update README to reflect SRIS source

## Testing
- `python -m py_compile nationale_assemblee_scraper_to_hf.py`
- `python -m py_compile sru_scraper.py sris_scraper.py upload_to_drive.py`


------
https://chatgpt.com/codex/tasks/task_e_686d6c96422883299eaabf81e9cbcb7a